### PR TITLE
#103 - Try catch Mailchimp API failure and auto skipping

### DIFF
--- a/mediathread/user_accounts/views.py
+++ b/mediathread/user_accounts/views.py
@@ -76,8 +76,11 @@ class RegistrationFormView(FormView):
 
         # subscribe in mailchimp
         if registration.subscribe_to_newsletter:
-            registration.subscribe_mailchimp_list(
-                settings.MAILCHIMP_REGISTRATION_LIST_ID)
+            try:
+                registration.subscribe_mailchimp_list(
+                    settings.MAILCHIMP_REGISTRATION_LIST_ID)
+            except Exception as e:
+                print e
 
         return complete_signup(self.request, registration.get_user(),
                                app_settings.EMAIL_VERIFICATION,


### PR DESCRIPTION
https://trello.com/c/5ObE8bq1/103-prevent-mailchimp-breaking-our-registration-flow

tested in local environment.
