### PR TITLE
Optimize autocomplete static files

### DIFF
--- a/mediathread/templates/base.html
+++ b/mediathread/templates/base.html
@@ -30,19 +30,17 @@
             <link rel="stylesheet" href="{% static 'css/mediathread.css' %}" media="screen" />
             {% block css %}{% endblock %}
         {% endcompress %}   
-        
-        {% block extrahead %}
-            <!--  For uncompress-able resources -->
-        {% endblock %}
+
         <script type="text/javascript" src="{% url django.views.i18n.javascript_catalog %}"></script>
-
-
         <script type="text/javascript">
             jQuery(function(){
                 $ = jQuery;
             });
         </script>
-        {% include "autocomplete_light/static.html" %}
+        {% block extrahead %}
+            <!--  For uncompress-able resources -->
+        {% endblock %}
+
     </head>
     
     {% course_role for request.user in course as role_in_course %}

--- a/mediathread/templates/course/create.html
+++ b/mediathread/templates/course/create.html
@@ -3,6 +3,10 @@
 
 {% block title %}Create a Course{% endblock title %}
 
+{% block extrahead %}
+    {% include "autocomplete_light/static.html" %}
+{% endblock %}
+
 {% block css %}
 <link rel="stylesheet" href="{% static 'css/bootstrap.css' %}" type="text/css" />
 {% endblock %}

--- a/mediathread/templates/user_accounts/registration_form.html
+++ b/mediathread/templates/user_accounts/registration_form.html
@@ -3,6 +3,10 @@
 
 {% block title %}Registration{% endblock title %}
 
+{% block extrahead %}
+    {% include "autocomplete_light/static.html" %}
+{% endblock %}
+
 {% block css %}
 <link rel="stylesheet" href="{% static 'css/bootstrap.css' %}" type="text/css" />
 {% endblock %}


### PR DESCRIPTION
I noticed that we were loading the static files for the autocomplete widget in the base.html template which causes the server to serve more static files than needed on most pages, so I moved that only to the templates that actually use the autocomplete widget.

I don't have time to test it though so Colin if you could just check whether it breaks something on the other pages (because I moved the extrahead block in the template a little lower). Thanks.
